### PR TITLE
fix: typo

### DIFF
--- a/exercises/01.fetching/03.problem.status/README.mdx
+++ b/exercises/01.fetching/03.problem.status/README.mdx
@@ -14,7 +14,7 @@ What we have now is:
 But that's not exactly clear.
 
 So instead, let's add a `status` variable that can be
-`'pending' | 'resolved' | 'rejected'` (start it out with `'pending'`).
+`'pending' | 'fulfilled' | 'rejected'` (start it out with `'pending'`).
 
 📜 To learn more about why this is important, read
 [Make Impossible States Impossible](https://kentcdodds.com/blog/make-impossible-states-impossible)


### PR DESCRIPTION
replace status `resolved` with `fulfilled` in Markdown file.