### PR TITLE
fix typo missing `c` on `optimistiShip`

### DIFF
--- a/exercises/03.optimistic/01.solution.optimistic/index.tsx
+++ b/exercises/03.optimistic/01.solution.optimistic/index.tsx
@@ -11,7 +11,7 @@ function App() {
 		delay: 300,
 		minDuration: 350,
 	})
-	const [optimistiShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
+	const [optimisticShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
 
 	function handleShipSelection(newShipName: string) {
 		startTransition(() => {
@@ -26,7 +26,7 @@ function App() {
 				<div className="details" style={{ opacity: isPending ? 0.6 : 1 }}>
 					<ErrorBoundary fallback={<ShipError shipName={shipName} />}>
 						<Suspense fallback={<ShipFallback shipName={shipName} />}>
-							<ShipDetails shipName={shipName} optimistiShip={optimistiShip} />
+							<ShipDetails shipName={shipName} optimisticShip={optimisticShip} />
 						</Suspense>
 					</ErrorBoundary>
 				</div>
@@ -139,14 +139,14 @@ function ShipButtons({
 
 function ShipDetails({
 	shipName,
-	optimistiShip,
+	optimisticShip,
 }: {
 	shipName: string
-	optimistiShip: Ship | null
+	optimisticShip: Ship | null
 }) {
 	// 🦉 you can change this delay to control how long loading the resource takes:
 	const delay = 2000
-	const ship = optimistiShip ?? use(getShip(shipName, delay))
+	const ship = optimisticShip ?? use(getShip(shipName, delay))
 	return (
 		<div className="ship-info">
 			<div className="ship-info__img-wrapper">

--- a/exercises/03.optimistic/02.problem.form-status/index.tsx
+++ b/exercises/03.optimistic/02.problem.form-status/index.tsx
@@ -11,7 +11,7 @@ function App() {
 		delay: 300,
 		minDuration: 350,
 	})
-	const [optimistiShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
+	const [optimisticShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
 
 	function handleShipSelection(newShipName: string) {
 		startTransition(() => {
@@ -26,7 +26,7 @@ function App() {
 				<div className="details" style={{ opacity: isPending ? 0.6 : 1 }}>
 					<ErrorBoundary fallback={<ShipError shipName={shipName} />}>
 						<Suspense fallback={<ShipFallback shipName={shipName} />}>
-							<ShipDetails shipName={shipName} optimistiShip={optimistiShip} />
+							<ShipDetails shipName={shipName} optimisticShip={optimisticShip} />
 						</Suspense>
 					</ErrorBoundary>
 				</div>
@@ -143,14 +143,14 @@ function ShipButtons({
 
 function ShipDetails({
 	shipName,
-	optimistiShip,
+	optimisticShip,
 }: {
 	shipName: string
-	optimistiShip: Ship | null
+	optimisticShip: Ship | null
 }) {
 	// 🦉 you can change this delay to control how long loading the resource takes:
 	const delay = 2000
-	const ship = optimistiShip ?? use(getShip(shipName, delay))
+	const ship = optimisticShip ?? use(getShip(shipName, delay))
 	return (
 		<div className="ship-info">
 			<div className="ship-info__img-wrapper">

--- a/exercises/03.optimistic/02.solution.form-status/index.tsx
+++ b/exercises/03.optimistic/02.solution.form-status/index.tsx
@@ -12,7 +12,7 @@ function App() {
 		delay: 300,
 		minDuration: 350,
 	})
-	const [optimistiShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
+	const [optimisticShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
 
 	function handleShipSelection(newShipName: string) {
 		startTransition(() => {
@@ -27,7 +27,7 @@ function App() {
 				<div className="details" style={{ opacity: isPending ? 0.6 : 1 }}>
 					<ErrorBoundary fallback={<ShipError shipName={shipName} />}>
 						<Suspense fallback={<ShipFallback shipName={shipName} />}>
-							<ShipDetails shipName={shipName} optimistiShip={optimistiShip} />
+							<ShipDetails shipName={shipName} optimisticShip={optimisticShip} />
 						</Suspense>
 					</ErrorBoundary>
 				</div>
@@ -149,14 +149,14 @@ function ShipButtons({
 
 function ShipDetails({
 	shipName,
-	optimistiShip,
+	optimisticShip,
 }: {
 	shipName: string
-	optimistiShip: Ship | null
+	optimisticShip: Ship | null
 }) {
 	// 🦉 you can change this delay to control how long loading the resource takes:
 	const delay = 2000
-	const ship = optimistiShip ?? use(getShip(shipName, delay))
+	const ship = optimisticShip ?? use(getShip(shipName, delay))
 	return (
 		<div className="ship-info">
 			<div className="ship-info__img-wrapper">

--- a/exercises/03.optimistic/03.problem.message/index.tsx
+++ b/exercises/03.optimistic/03.problem.message/index.tsx
@@ -12,7 +12,7 @@ function App() {
 		delay: 300,
 		minDuration: 350,
 	})
-	const [optimistiShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
+	const [optimisticShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
 
 	function handleShipSelection(newShipName: string) {
 		startTransition(() => {
@@ -27,7 +27,7 @@ function App() {
 				<div className="details" style={{ opacity: isPending ? 0.6 : 1 }}>
 					<ErrorBoundary fallback={<ShipError shipName={shipName} />}>
 						<Suspense fallback={<ShipFallback shipName={shipName} />}>
-							<ShipDetails shipName={shipName} optimistiShip={optimistiShip} />
+							<ShipDetails shipName={shipName} optimisticShip={optimisticShip} />
 						</Suspense>
 					</ErrorBoundary>
 				</div>
@@ -157,14 +157,14 @@ function ShipButtons({
 
 function ShipDetails({
 	shipName,
-	optimistiShip,
+	optimisticShip,
 }: {
 	shipName: string
-	optimistiShip: Ship | null
+	optimisticShip: Ship | null
 }) {
 	// 🦉 you can change this delay to control how long loading the resource takes:
 	const delay = 2000
-	const ship = optimistiShip ?? use(getShip(shipName, delay))
+	const ship = optimisticShip ?? use(getShip(shipName, delay))
 	return (
 		<div className="ship-info">
 			<div className="ship-info__img-wrapper">

--- a/exercises/03.optimistic/03.solution.message/index.tsx
+++ b/exercises/03.optimistic/03.solution.message/index.tsx
@@ -12,7 +12,7 @@ function App() {
 		delay: 300,
 		minDuration: 350,
 	})
-	const [optimistiShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
+	const [optimisticShip, setOptimisticShip] = useOptimistic<Ship | null>(null)
 
 	function handleShipSelection(newShipName: string) {
 		startTransition(() => {
@@ -27,7 +27,7 @@ function App() {
 				<div className="details" style={{ opacity: isPending ? 0.6 : 1 }}>
 					<ErrorBoundary fallback={<ShipError shipName={shipName} />}>
 						<Suspense fallback={<ShipFallback shipName={shipName} />}>
-							<ShipDetails shipName={shipName} optimistiShip={optimistiShip} />
+							<ShipDetails shipName={shipName} optimisticShip={optimisticShip} />
 						</Suspense>
 					</ErrorBoundary>
 				</div>
@@ -153,14 +153,14 @@ function ShipButtons({
 
 function ShipDetails({
 	shipName,
-	optimistiShip,
+	optimisticShip,
 }: {
 	shipName: string
-	optimistiShip: Ship | null
+	optimisticShip: Ship | null
 }) {
 	// 🦉 you can change this delay to control how long loading the resource takes:
 	const delay = 2000
-	const ship = optimistiShip ?? use(getShip(shipName, delay))
+	const ship = optimisticShip ?? use(getShip(shipName, delay))
 	return (
 		<div className="ship-info">
 			<div className="ship-info__img-wrapper">


### PR DESCRIPTION
Here is a screenshot of the solution. 

We have a diff because it's `optimistiShip` and not `optimisticShip`.

![image](https://github.com/user-attachments/assets/8ed5c3c7-b11b-438d-bd19-564a34fecbbd)

That bugs me so much because the videos are recorded without typo 😅

![CleanShot 2024-10-17 at 13 37 46](https://github.com/user-attachments/assets/782b4fa6-0980-4379-9cdf-bd8bcdcf0639)
